### PR TITLE
Check whether decoding is successful or not

### DIFF
--- a/libhesai/Lidar/lidar.cc
+++ b/libhesai/Lidar/lidar.cc
@@ -437,7 +437,10 @@ void Lidar<T_Point>::ParserThread() {
 #endif
   while (running_) {
     LidarDecodedPacket<T_Point> decoded_packet;
-    decoded_packets_buffer_.try_pop_front(decoded_packet);
+    int status = decoded_packets_buffer_.try_pop_front(decoded_packet);
+    if (!status){
+      continue;
+    }
     if (handle_thread_count_ < 2) {
       udp_parser_->ComputeXYZI(frame_, decoded_packet);
       continue;


### PR DESCRIPTION
Occasionally, the try_pop_front method may return an unsuccessful decoding status of zero. When this happens, the later ComputeXYZI call may crash the entire program. To prevent this, a status check is added to continue to the next packet instead of attempting to parse the blank decoded packet structure. 