### PR TITLE
include cstdint for types used in auto_tick_count.h

### DIFF
--- a/libhesai/include/auto_tick_count.h
+++ b/libhesai/include/auto_tick_count.h
@@ -34,6 +34,7 @@ ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <string>
 #include <vector>
 #include <iostream>
+#include <cstdint>
 namespace hesai
 {
 namespace lidar


### PR DESCRIPTION
The compilation throws an error due to the types "uint32_t, uint16_t, ...." used in the auto_tick_count.h file, which belong to the cstdint library in cpp_std_11