### PR TITLE
Fix: Allow node renaming in ROS2 to avoid duplicate nodes (#22)

### DIFF
--- a/libhesai/driver_param.h
+++ b/libhesai/driver_param.h
@@ -145,6 +145,8 @@ typedef struct InputParam
   bool send_packet_ros;
   bool send_point_cloud_ros;
   std::string frame_id;
+  std::string ros_node_name;
+
 
   std::string ros_send_packet_topic = NULL_TOPIC;
   std::string ros_send_point_topic = NULL_TOPIC;


### PR DESCRIPTION
## Fix: Allow node renaming in ROS2
This PR addresses the issue where launching multiple Hesai LiDAR sensors results in multiple nodes with the same name.

### 🔹 Changes:
- Added a new parameter `ros_node_name` in libehesai/driver_param.h

The fix in this submodule and would influence the Pull Request on HesaiLidar_ROS_2.0
Relative to the issue [https://github.com/HesaiTechnology/HesaiLidar_ROS_2.0/issues/22]()