### PR TITLE
fix: add code for imu callback in GPU driver

### DIFF
--- a/driver/hesai_lidar_sdk_gpu.cuh
+++ b/driver/hesai_lidar_sdk_gpu.cuh
@@ -216,6 +216,10 @@ public:
         }
         continue;
       }
+      if (lidar_ptr_->frame_.imu_config.flag)
+      {
+        if (imu_cb_) imu_cb_(lidar_ptr_->frame_.imu_config);
+      }
 
       //one frame is receive completely, split frame
       if (lidar_ptr_->frame_.scan_complete) {


### PR DESCRIPTION
The GPU driver is missing code for the IMU callback. This PR fixes that.
Check this bug ticket https://github.com/HesaiTechnology/HesaiLidar_SDK_2.0/issues/28