### PR TITLE
Support commands with tests

### DIFF
--- a/driver/hesai_lidar_sdk.hpp
+++ b/driver/hesai_lidar_sdk.hpp
@@ -48,7 +48,7 @@ private:
   std::function<void(const LidarDecodedFrame<T_Point>&)> point_cloud_cb_;
   std::function<void(const u8Array_t&)> correction_cb_;
   std::function<void(const uint32_t &, const uint32_t &)> pkt_loss_cb_;
-  std::function<void(const uint8_t&, const u8Array_t&)> ptp_cb_;
+  std::function<void(const uint16_t&, const u8Array_t&)> ptp_cb_;
   std::function<void(const FaultMessageInfo&)> fault_message_cb_;
   std::function<void(const LidarImuData&)> imu_cb_;
   bool is_thread_runing_;
@@ -336,16 +336,16 @@ public:
           if (ptp_cb_ && lidar_ptr_->frame_.frame_index % 100 == 1)
           {
             u8Array_t ptp_status;
-            u8Array_t ptp_lock_offset;
+            uint16_t ptp_lock_offset = 0;
             int ret_status = lidar_ptr_->ptc_client_->GetPTPDiagnostics(ptp_status, 1); // ptp_query_type = 1
             int ret_offset = lidar_ptr_->ptc_client_->GetPTPLockOffset(ptp_lock_offset);
             if (ret_status != 0 || ret_offset != 0)
             {
-              LogInfo("-->%d %d %zu %zu", ret_status, ret_offset, ptp_status.size(), ptp_lock_offset.size());
+              LogInfo("-->%d %d %zu", ret_status, ret_offset, ptp_status.size());
             }
             else
             {
-              ptp_cb_(ptp_lock_offset.front(), ptp_status);
+              ptp_cb_(ptp_lock_offset, ptp_status);
             }
           }
           if (correction_cb_ && lidar_ptr_->frame_.frame_index % 1000 == 1)
@@ -460,7 +460,7 @@ public:
   void RegRecvCallback(const std::function<void (const uint32_t &, const uint32_t &)>& callback) {
     pkt_loss_cb_ = callback;
   }
-  void RegRecvCallback(const std::function<void (const uint8_t&, const u8Array_t&)>& callback) {
+  void RegRecvCallback(const std::function<void (const uint16_t&, const u8Array_t&)>& callback) {
     ptp_cb_ = callback;
   }
   void RegRecvCallback(const std::function<void (const FaultMessageInfo&)>& callback) {

--- a/libhesai/PtcClient/include/ptc_client.h
+++ b/libhesai/PtcClient/include/ptc_client.h
@@ -50,6 +50,7 @@ namespace lidar
 {
 const uint8_t  kPTCGetLidarCalibration = 0x05;
 const uint8_t  kPTCGetPTPDiagnostics= 0x06;
+const uint8_t  kPTCGetConfigInfo = 0x08;
 const uint8_t  kPTCGetInventoryInfo = 0x07;
 const uint8_t  kPTCGetLidarStatus = 0x09;
 const uint8_t  kPTCGetFpgaRegister = 0x0C;
@@ -121,6 +122,7 @@ class PtcClient {
 
   u8Array_t GetCorrectionInfo();
   int GetLidarStatus();
+  int GetConfigInfo();
   int GetPTPDiagnostics (u8Array_t &dataOut, uint8_t query_type);
   int GetPTPLockOffset(u8Array_t &dataOut);
   int GetCorrectionInfo(u8Array_t &dataOut);

--- a/libhesai/PtcClient/include/ptc_client.h
+++ b/libhesai/PtcClient/include/ptc_client.h
@@ -67,6 +67,7 @@ const uint8_t  KPTCGetFov = 0x23;
 const uint8_t  kPTCResetLidar = 0x25;
 const uint8_t  kPTCGetFreezeFrames = 0x30;
 const uint8_t  kPTCGetLidarOperationLog = 0x38;
+const uint8_t  kPTCSetPTPLockOffset = 0x39;
 const uint8_t  kPTCGetPTPLockOffset = 0x3a;
 const uint8_t  kPTCUpgradeLidar = 0x83;
 const uint8_t  kPTCGetUpgradeLidarLog = 0x87;
@@ -78,6 +79,30 @@ const uint32_t kPTCUpgradeLidarSubCmd = 0x0000000D;
 const uint32_t kPTCGetRetroSubCmd = 0x0000011E;
 const uint32_t kPTCJT16CommandSubCmd = 0x00000138;
 const uint32_t kPTCJT16SetBaudrate = 0x00000139;
+// JT128 point cloud filter / ultra-precise (cmd 0xFF extended subcommands)
+const uint32_t kPTCGetPointCloudDescriptorSubCmd = 0x00000120;  // descriptor table
+const uint32_t kPTCSetPointCloudConfigSubCmd = 0x00000121;      // SET [ultra, filter]
+const uint32_t kPTCGetPointCloudConfigSubCmd = 0x00000122;      // GET live ultra + filter
+
+// JT128 PTP lock offset threshold (0x39 SET / 0x3a GET): 2-byte BE uint16, 1-1000 us.
+static constexpr uint16_t kPtpLockOffsetMinUs = 1;
+static constexpr uint16_t kPtpLockOffsetMaxUs = 1000;
+static constexpr size_t kPtpDiagnosticsPayloadLen = 24;
+static constexpr size_t kLidarStatusMinLen = 49;
+
+static constexpr uint8_t kPointCloudKeepCurrent = 0xFF;
+static constexpr size_t kPointCloudLiveConfigMinLen = 6;
+static constexpr size_t kPointCloudDescriptorTableMinLen = 8;
+
+// JT128 spin_rate (PTC 0x17 SET / config offset 20): unsigned short, 600 or 1200 RPM only.
+static constexpr uint16_t kSpinRateRpm600 = 600;
+static constexpr uint16_t kSpinRateRpm1200 = 1200;
+static constexpr uint16_t kSpinRateRpmDefault = kSpinRateRpm600;
+
+inline bool IsValidSpinRateRpm(uint32_t rpm)
+{
+  return rpm == kSpinRateRpm600 || rpm == kSpinRateRpm1200;
+}
 
 typedef struct UpgradeProgress {
     int total_packets;
@@ -122,9 +147,27 @@ class PtcClient {
 
   u8Array_t GetCorrectionInfo();
   int GetLidarStatus();
+  int GetLidarStatusRaw(u8Array_t &dataOut);
+  bool GetLidarPtpStatus(uint8_t &ptp_status);
   int GetConfigInfo();
   int GetPTPDiagnostics (u8Array_t &dataOut, uint8_t query_type);
-  int GetPTPLockOffset(u8Array_t &dataOut);
+  bool SetPTPLockOffset(uint16_t offset_us);
+  int GetPTPLockOffset(uint16_t &offset_us);
+  int GetConfigInfoRaw(u8Array_t &dataOut);
+  bool GetReturnMode(uint8_t &return_mode);
+  bool GetSpinRate(uint16_t &spin_rate);
+  bool SetPointCloudConfig(uint8_t ultra_precise, uint8_t filter);
+  bool GetPointCloudConfig(uint8_t &ultra_precise, uint8_t &filter);
+  int GetPointCloudConfigRaw(u8Array_t &dataOut);
+  int GetPointCloudDescriptorRaw(u8Array_t &dataOut);
+  static bool IsPointCloudDescriptorTable(const u8Array_t &payload);
+  bool GetPointCloudMergeBase(uint8_t &ultra, uint8_t &filter,
+                              bool have_cache, uint8_t cached_ultra,
+                              uint8_t cached_filter);
+  bool SetPointCloudConfigSelective(uint8_t ultra_precise, uint8_t filter_type,
+                                    bool have_cache = false,
+                                    uint8_t cached_ultra = 0,
+                                    uint8_t cached_filter = 0);
   int GetCorrectionInfo(u8Array_t &dataOut);
   int GetFiretimesInfo(u8Array_t &dataOut);
   int GetChannelConfigInfo(u8Array_t &dataOut);
@@ -234,7 +277,7 @@ class PtcClient {
   /**
    * @brief Set the spin_speed of lidar
    * 
-   * @param speed                     Expected spinspeed, it is important to note that you must fill in the RPM supported by the radar you are using
+   * @param speed                     JT128: 600 or 1200 RPM only (600 default)
    * @return true 
    * @return false 
    */

--- a/libhesai/PtcClient/src/ptc_client.cc
+++ b/libhesai/PtcClient/src/ptc_client.cc
@@ -390,6 +390,7 @@ bool PtcClient::GetValFromOutput(uint8_t cmd, uint8_t retcode, const u8Array_t &
   return ptc_parser_->PtcStreamDecode(cmd, retcode, payload, start_pos, length, res);
 }
 
+
 u8Array_t PtcClient::GetCorrectionInfo() {
   u8Array_t dataIn;
   u8Array_t dataOut;
@@ -415,6 +416,95 @@ T extractField(const u8Array_t& data, size_t& offset) {
         field = static_cast<T>((field << 8) | data[offset++]);
     }
     return field;
+}
+
+int PtcClient::GetConfigInfo() {
+  u8Array_t dataIn, dataOut;
+  int ret = -1;
+  ret = this->QueryCommand(dataIn, dataOut,
+                           kPTCGetConfigInfo);
+  if (ret == 0 && !dataOut.empty()) {
+    // according to JT128_TCP_API_ARJ01-en-250920.pdf
+    uint32_t ipaddr;
+    uint32_t mask;
+    uint32_t gateway;
+    uint32_t dest_ipaddr;
+    uint16_t dest_point_cloud_udp_port;
+    uint16_t dest_gnss_udp_port; // Not Used
+    uint16_t spin_rate;
+    uint8_t sync_enable;
+    uint16_t sync_angle;
+    uint16_t start_angle; // Not Used
+    uint16_t end_angle; // Not Used
+    uint8_t clock_source;
+    uint8_t udp_seq;
+    uint8_t trigger_mode;
+    uint8_t return_mode;
+    uint8_t standby_mode;
+    uint8_t motor_status; // Not Used
+    uint8_t vlan_flag;
+    uint16_t vlan_id;
+    uint8_t nmea_sentence; // unsigned char, Not Used
+    uint8_t noise_filtering; // unsigned char, Not Used
+    uint8_t reflectivity_mapping; // unsigned char, Not Used
+
+    size_t offset = 0;
+    ipaddr = extractField<uint32_t>(dataOut, offset);
+    mask = extractField<uint32_t>(dataOut, offset);
+    gateway = extractField<uint32_t>(dataOut, offset);
+    dest_ipaddr = extractField<uint32_t>(dataOut, offset);
+    dest_point_cloud_udp_port = extractField<uint16_t>(dataOut, offset);
+    dest_gnss_udp_port = extractField<uint16_t>(dataOut, offset);
+    spin_rate = extractField<uint16_t>(dataOut, offset);
+    sync_enable = extractField<uint8_t>(dataOut, offset);
+    sync_angle = extractField<uint16_t>(dataOut, offset);
+    start_angle = extractField<uint16_t>(dataOut, offset);
+    end_angle = extractField<uint16_t>(dataOut, offset);
+    clock_source = extractField<uint8_t>(dataOut, offset);
+    udp_seq = extractField<uint8_t>(dataOut, offset);
+    trigger_mode = extractField<uint8_t>(dataOut, offset);
+    return_mode = extractField<uint8_t>(dataOut, offset);
+    standby_mode = extractField<uint8_t>(dataOut, offset);
+    motor_status = extractField<uint8_t>(dataOut, offset);
+    vlan_flag = extractField<uint8_t>(dataOut, offset);
+    vlan_id = extractField<uint16_t>(dataOut, offset);
+    nmea_sentence = extractField<uint8_t>(dataOut, offset);
+    noise_filtering = extractField<uint8_t>(dataOut, offset);
+    reflectivity_mapping = extractField<uint8_t>(dataOut, offset);
+
+    uint8_t *ip = reinterpret_cast<uint8_t*>(&ipaddr);
+    uint8_t *mask_ip = reinterpret_cast<uint8_t*>(&mask);
+    uint8_t *gateway_ip = reinterpret_cast<uint8_t*>(&gateway);
+    uint8_t *dest_ip = reinterpret_cast<uint8_t*>(&dest_ipaddr);
+
+    printf("---------- LiDAR Configuration ----------\n"
+          "Device IP address: %u.%u.%u.%u\n"
+          "Device Subnet mask: %u.%u.%u.%u\n"
+          "Device Gateway: %u.%u.%u.%u\n"
+          "Destination IP address: %u.%u.%u.%u\n"
+          "Destination Point cloud + IMU UDP port: %u\n"
+          "GNSS UDP port: %u\n"
+          "Spin rate: %u RPM\n"
+          "Sync enable: %u, Sync angle: %u\n"
+          "Clock source: %u, UDP sequence: %u\n"
+          "Trigger mode: %u, Return mode: %u\n"
+          "Standby mode: %u, VLAN flag: %u, VLAN ID: %u (4095 means invalid)\n"
+          "----------------------------------------\n",
+          ip[3], ip[2], ip[1], ip[0],
+          mask_ip[3], mask_ip[2], mask_ip[1], mask_ip[0],
+          gateway_ip[3], gateway_ip[2], gateway_ip[1], gateway_ip[0],
+          dest_ip[3], dest_ip[2], dest_ip[1], dest_ip[0],
+          dest_point_cloud_udp_port,
+          dest_gnss_udp_port,
+          spin_rate,
+          sync_enable, sync_angle,
+          clock_source, udp_seq,
+          trigger_mode, return_mode,
+          standby_mode, vlan_flag, vlan_id);
+    return 0;
+  } else {
+    return -1;
+  }
 }
 
 int PtcClient::GetPTPDiagnostics (u8Array_t &dataOut, uint8_t query_type) {

--- a/libhesai/PtcClient/src/ptc_client.cc
+++ b/libhesai/PtcClient/src/ptc_client.cc
@@ -521,17 +521,270 @@ int PtcClient::GetPTPDiagnostics (u8Array_t &dataOut, uint8_t query_type) {
   }
 }
 
-int PtcClient::GetPTPLockOffset(u8Array_t &dataOut)
+int PtcClient::GetPTPLockOffset(uint16_t &offset_us)
+{
+  u8Array_t dataIn, dataOut;
+  int ret = QueryCommand(dataIn, dataOut, kPTCGetPTPLockOffset);
+  if (ret == 0 && dataOut.size() >= 2) {
+    offset_us = static_cast<uint16_t>(
+        (static_cast<uint16_t>(dataOut[0]) << 8) | dataOut[1]);
+    return 0;
+  }
+  return -1;
+}
+
+bool PtcClient::SetPTPLockOffset(uint16_t offset_us)
+{
+  if (offset_us < kPtpLockOffsetMinUs || offset_us > kPtpLockOffsetMaxUs) {
+    return false;
+  }
+  u8Array_t input, output;
+  input.push_back(static_cast<uint8_t>(offset_us >> 8));
+  input.push_back(static_cast<uint8_t>(offset_us >> 0));
+  if (QueryCommand(input, output, kPTCSetPTPLockOffset) != 0)
+    return false;
+  return true;
+}
+
+namespace {
+void AppendU32BE(u8Array_t &out, uint32_t value)
+{
+  out.push_back(static_cast<uint8_t>(value >> 24));
+  out.push_back(static_cast<uint8_t>(value >> 16));
+  out.push_back(static_cast<uint8_t>(value >> 8));
+  out.push_back(static_cast<uint8_t>(value >> 0));
+}
+
+bool StripExtendedSubcmdEcho(u8Array_t &payload, uint32_t subcmd)
+{
+  if (payload.size() >= 4 &&
+      payload[0] == static_cast<uint8_t>(subcmd >> 24) &&
+      payload[1] == static_cast<uint8_t>(subcmd >> 16) &&
+      payload[2] == static_cast<uint8_t>(subcmd >> 8) &&
+      payload[3] == static_cast<uint8_t>(subcmd >> 0)) {
+    payload.erase(payload.begin(), payload.begin() + 4);
+    return true;
+  }
+  return false;
+}
+}  // namespace
+
+int PtcClient::GetConfigInfoRaw(u8Array_t &dataOut)
 {
   u8Array_t dataIn;
-  int ret = -1;
-  ret = QueryCommand(dataIn, dataOut,
-                           kPTCGetPTPLockOffset);
+  int ret = QueryCommand(dataIn, dataOut, kPTCGetConfigInfo);
   if (ret == 0 && !dataOut.empty()) {
     return 0;
-  } else {
-    return -1;
   }
+  return -1;
+}
+
+bool PtcClient::GetReturnMode(uint8_t &return_mode)
+{
+  u8Array_t dataOut;
+  if (GetConfigInfoRaw(dataOut) != 0) {
+    return false;
+  }
+  // JT128_TCP_API: return_mode field offset 32
+  if (dataOut.size() <= 32) {
+    return false;
+  }
+  return_mode = dataOut[32];
+  return true;
+}
+
+bool PtcClient::GetSpinRate(uint16_t &spin_rate)
+{
+  u8Array_t dataOut;
+  if (GetConfigInfoRaw(dataOut) != 0) {
+    return false;
+  }
+  // JT128_TCP_API: spin_rate uint16 BE at offset 20
+  if (dataOut.size() < 22) {
+    return false;
+  }
+  spin_rate = static_cast<uint16_t>(
+      (static_cast<uint16_t>(dataOut[20]) << 8) | dataOut[21]);
+  return true;
+}
+
+namespace {
+bool ParsePointCloudConfigPayload(
+    const u8Array_t &payload, uint32_t subcmd,
+    uint8_t &ultra_precise, uint8_t &filter)
+{
+  if (payload.size() >= 6 &&
+      payload[0] == static_cast<uint8_t>(subcmd >> 24) &&
+      payload[1] == static_cast<uint8_t>(subcmd >> 16) &&
+      payload[2] == static_cast<uint8_t>(subcmd >> 8) &&
+      payload[3] == static_cast<uint8_t>(subcmd >> 0)) {
+    ultra_precise = payload[4];
+    filter = payload[5];
+    return true;
+  }
+  u8Array_t stripped = payload;
+  if (StripExtendedSubcmdEcho(stripped, subcmd) && stripped.size() >= 2) {
+    ultra_precise = stripped[0];
+    filter = stripped[1];
+    return true;
+  }
+  if (payload.size() >= 2) {
+    ultra_precise = payload[0];
+    filter = payload[1];
+    return true;
+  }
+  return false;
+}
+}  // namespace
+
+bool PtcClient::SetPointCloudConfig(uint8_t ultra_precise, uint8_t filter)
+{
+  // JT128 SET 0x121 payload is two bytes [ultra_precise, filter_type] (PDF typo: 1 byte).
+  u8Array_t input, output;
+  AppendU32BE(input, kPTCSetPointCloudConfigSubCmd);
+  input.push_back(ultra_precise);
+  input.push_back(filter);
+  if (QueryCommand(input, output, kPTCHasSubCommand) != 0) {
+    return false;
+  }
+  return true;
+}
+
+int PtcClient::GetPointCloudConfigRaw(u8Array_t &dataOut)
+{
+  u8Array_t input;
+  AppendU32BE(input, kPTCGetPointCloudConfigSubCmd);
+  int ret = QueryCommand(input, dataOut, kPTCHasSubCommand);
+  if (ret == 0 && !dataOut.empty()) {
+    return 0;
+  }
+  return -1;
+}
+
+int PtcClient::GetPointCloudDescriptorRaw(u8Array_t &dataOut)
+{
+  u8Array_t input;
+  AppendU32BE(input, kPTCGetPointCloudDescriptorSubCmd);
+  int ret = QueryCommand(input, dataOut, kPTCHasSubCommand);
+  if (ret == 0 && !dataOut.empty()) {
+    return 0;
+  }
+  return -1;
+}
+
+bool PtcClient::GetPointCloudConfig(uint8_t &ultra_precise, uint8_t &filter)
+{
+  u8Array_t output;
+  if (GetPointCloudConfigRaw(output) != 0) {
+    return false;
+  }
+  if (output.size() < kPointCloudLiveConfigMinLen) {
+    return false;
+  }
+  return ParsePointCloudConfigPayload(
+      output, kPTCGetPointCloudConfigSubCmd, ultra_precise, filter);
+}
+
+bool PtcClient::IsPointCloudDescriptorTable(const u8Array_t &payload)
+{
+  return payload.size() >= kPointCloudDescriptorTableMinLen &&
+         payload[0] ==
+             static_cast<uint8_t>(kPTCGetPointCloudDescriptorSubCmd >> 24) &&
+         payload[1] ==
+             static_cast<uint8_t>(kPTCGetPointCloudDescriptorSubCmd >> 16) &&
+         payload[2] ==
+             static_cast<uint8_t>(kPTCGetPointCloudDescriptorSubCmd >> 8) &&
+         payload[3] ==
+             static_cast<uint8_t>(kPTCGetPointCloudDescriptorSubCmd >> 0);
+}
+
+bool PtcClient::GetPointCloudMergeBase(uint8_t &ultra, uint8_t &filter,
+                                       bool have_cache, uint8_t cached_ultra,
+                                       uint8_t cached_filter)
+{
+  if (have_cache) {
+    ultra = cached_ultra;
+    filter = cached_filter;
+    return true;
+  }
+  if (GetPointCloudConfig(ultra, filter)) {
+    return true;
+  }
+  ultra = 0;
+  filter = 0;
+  return true;
+}
+
+bool PtcClient::SetPointCloudConfigSelective(uint8_t ultra_precise,
+                                             uint8_t filter_type,
+                                             bool have_cache,
+                                             uint8_t cached_ultra,
+                                             uint8_t cached_filter)
+{
+  if (ultra_precise == kPointCloudKeepCurrent &&
+      filter_type == kPointCloudKeepCurrent) {
+    return false;
+  }
+  uint8_t base_ultra = 0;
+  uint8_t base_filter = 0;
+  GetPointCloudMergeBase(base_ultra, base_filter, have_cache, cached_ultra,
+                         cached_filter);
+  const uint8_t ultra =
+      (ultra_precise == kPointCloudKeepCurrent) ? base_ultra : ultra_precise;
+  const uint8_t filter =
+      (filter_type == kPointCloudKeepCurrent) ? base_filter : filter_type;
+  return SetPointCloudConfig(ultra, filter);
+}
+
+namespace {
+const char *PtpStatusName(uint8_t status)
+{
+  switch (status) {
+    case 0: return "Free run";
+    case 1: return "Tracking";
+    case 2: return "Locked";
+    case 3: return "Frozen";
+    default: return "unknown";
+  }
+}
+
+bool ParseLidarPtpStatus(const u8Array_t &dataOut, uint8_t &ptp_status)
+{
+  if (dataOut.size() < kLidarStatusMinLen) {
+    return false;
+  }
+  size_t offset = 0;
+  (void)extractField<uint32_t>(dataOut, offset);
+  (void)extractField<uint16_t>(dataOut, offset);
+  for (int i = 0; i < 8; ++i) {
+    (void)extractField<uint32_t>(dataOut, offset);
+  }
+  (void)extractField<uint8_t>(dataOut, offset);
+  (void)extractField<uint8_t>(dataOut, offset);
+  (void)extractField<uint32_t>(dataOut, offset);
+  (void)extractField<uint32_t>(dataOut, offset);
+  ptp_status = extractField<uint8_t>(dataOut, offset);
+  return true;
+}
+}  // namespace
+
+int PtcClient::GetLidarStatusRaw(u8Array_t &dataOut)
+{
+  u8Array_t dataIn;
+  int ret = QueryCommand(dataIn, dataOut, kPTCGetLidarStatus);
+  if (ret == 0 && !dataOut.empty()) {
+    return 0;
+  }
+  return -1;
+}
+
+bool PtcClient::GetLidarPtpStatus(uint8_t &ptp_status)
+{
+  u8Array_t dataOut;
+  if (GetLidarStatusRaw(dataOut) != 0) {
+    return false;
+  }
+  return ParseLidarPtpStatus(dataOut, ptp_status);
 }
 
 int PtcClient::GetLidarStatus() {
@@ -573,10 +826,10 @@ int PtcClient::GetLidarStatus() {
            "Top circuit RT4: %u\n"
            "GPS PPS status: %u, GPS NMEA status: %u\n"
            "System start-up times: %u, Total time in operation: %u\n"
-           "PTP status: %u\n"
+           "PTP status: %u (%s)\n"
     , systemp_uptime, motor_speed, temperature[0], temperature[1],temperature[2], temperature[3],
     temperature[4], temperature[5], temperature[6], temperature[7], gps_pps_lock, gps_gprmc_status,
-    startup_times, total_operation_time, ptp_status);
+    startup_times, total_operation_time, ptp_status, PtpStatusName(ptp_status));
     printf("Lidar Status Size: %zu\n", offset);
     return 0;
   } else {
@@ -754,6 +1007,9 @@ bool PtcClient::SetStandbyMode(uint32_t standby_mode)
 
 bool PtcClient::SetSpinSpeed(uint32_t speed)
 {
+  if (!IsValidSpinRateRpm(speed)) {
+    return false;
+  }
   u8Array_t input2, output2;
   input2.push_back(static_cast<uint8_t>(speed >> 8));
   input2.push_back(static_cast<uint8_t>(speed >> 0));

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -121,6 +121,23 @@ else(LASlib_FOUND)
     message(STATUS "LASlib not found, las_tool will be skipped")
 endif(LASlib_FOUND)
 
+# Stretch Lidar configuration tools
+add_executable(stretch_configure_left_lidar
+  ./stretch_configure_left_lidar.cc
+)
+
+target_link_libraries(stretch_configure_left_lidar
+  hesai_sdk_lib
+)
+
+add_executable(stretch_configure_right_lidar
+  ./stretch_configure_right_lidar.cc
+)
+
+target_link_libraries(stretch_configure_right_lidar
+  hesai_sdk_lib
+)
+
 # ============================================
 # 构建信息摘要
 # ============================================

--- a/tool/stretch_configure_left_lidar.cc
+++ b/tool/stretch_configure_left_lidar.cc
@@ -1,0 +1,72 @@
+#include "hesai_lidar_sdk.hpp"
+#include <fstream>
+#include <thread>
+#include <chrono>
+#include <cstdlib> // for getenv
+#include <filesystem> // for std::filesystem::create_directories
+
+
+int main(int argc, char *argv[])
+{
+  HesaiLidarSdk<LidarPointXYZICRT> sample;
+  DriverParam param;
+
+  // assign param
+  param.use_gpu = false;
+  param.input_param.source_type = DATA_FROM_LIDAR;
+  param.input_param.device_ip_address = "192.168.1.201";
+  param.input_param.udp_port = 2368;
+  param.input_param.is_use_ptc = true;
+  param.input_param.ptc_port = 9347;
+  param.input_param.pcap_path = "Your pcap file path";
+  param.input_param.correction_file_path = "Your correction file path";
+  param.input_param.firetimes_path = "Your firetime file path";
+
+  param.decoder_param.distance_correction_flag = false;
+  param.decoder_param.socket_buffer_size = 262144000;
+
+  //init lidar with param
+  sample.Init(param);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  //Print out lidar config
+  sample.lidar_ptr_->ptc_client_->GetConfigInfo();
+
+//   //Print out lidar status
+//   sample.lidar_ptr_->ptc_client_->GetLidarStatus();
+
+  //Save correction info
+  u8Array_t sData;
+  if (sample.lidar_ptr_->ptc_client_->GetCorrectionInfo(sData) != 0) {
+    printf("FAIL: Can't download lidar calibration");
+    return -1;
+  }
+  std::string base_path = std::getenv("HELLO_FLEET_PATH");
+  std::string fleet_id  = std::getenv("HELLO_FLEET_ID");
+  std::string save_dir = base_path + "/" + fleet_id + "/calibration_hesais";
+  std::filesystem::create_directories(save_dir);
+  std::string file_path = save_dir + "/left_lidar_calibration.dat";
+  std::ofstream fout(file_path, std::ios::out | std::ios::binary);
+  if (!fout) {
+    printf("FAIL: Can't open file for writing lidar calibration out");
+    return -1;
+  }
+  fout.write(reinterpret_cast<const char*>(sData.data()), sData.size());
+  fout.close();
+  printf("Saved calibration to %s (%zu bytes)\n", file_path.c_str(), sData.size());
+
+  //Set return mode to strongest
+  sample.lidar_ptr_->ptc_client_->SetReturnMode(1); // 1 -> "Strongest" only. Should yield around 115200 points per frame.
+  printf("Set return mode to strongest\n");
+
+  //Set destination (point cloud + IMU) port to 2378
+  sample.lidar_ptr_->ptc_client_->SetDesIpandPort("255.255.255.255", 2378, 0); // destination ip, data port, GNSS port (0 means invalid)
+  printf("Set destination port to 2378\n");
+
+  //Set device ip address to be 192.168.1.202 (emphasis on 202, not 201)
+  sample.lidar_ptr_->ptc_client_->SetNet("192.168.1.202", "255.255.255.0", "192.168.1.1", 0, 4095); // ip, subnet mask, gateway, vlan is_enabled, vlan id (4095 means invalid)
+  printf("Set device ip address to be 192.168.1.202 (emphasis on 202, not 201)\n");
+
+  printf("Done. Exiting...\n");
+  return 0;
+}

--- a/tool/stretch_configure_right_lidar.cc
+++ b/tool/stretch_configure_right_lidar.cc
@@ -1,0 +1,64 @@
+#include "hesai_lidar_sdk.hpp"
+#include <fstream>
+#include <thread>
+#include <chrono>
+#include <cstdlib> // for getenv
+#include <filesystem> // for std::filesystem::create_directories
+
+
+int main(int argc, char *argv[])
+{
+  HesaiLidarSdk<LidarPointXYZICRT> sample;
+  DriverParam param;
+
+  // assign param
+  param.use_gpu = false;
+  param.input_param.source_type = DATA_FROM_LIDAR;
+  param.input_param.device_ip_address = "192.168.1.201";
+  param.input_param.udp_port = 2368;
+  param.input_param.is_use_ptc = true;
+  param.input_param.ptc_port = 9347;
+  param.input_param.pcap_path = "Your pcap file path";
+  param.input_param.correction_file_path = "Your correction file path";
+  param.input_param.firetimes_path = "Your firetime file path";
+
+  param.decoder_param.distance_correction_flag = false;
+  param.decoder_param.socket_buffer_size = 262144000;
+
+  //init lidar with param
+  sample.Init(param);
+  std::this_thread::sleep_for(std::chrono::milliseconds(1000));
+
+  //Print out lidar config
+  sample.lidar_ptr_->ptc_client_->GetConfigInfo();
+
+//   //Print out lidar status
+//   sample.lidar_ptr_->ptc_client_->GetLidarStatus();
+
+  //Save correction info
+  u8Array_t sData;
+  if (sample.lidar_ptr_->ptc_client_->GetCorrectionInfo(sData) != 0) {
+    printf("FAIL: Can't download lidar calibration");
+    return -1;
+  }
+  std::string base_path = std::getenv("HELLO_FLEET_PATH");
+  std::string fleet_id  = std::getenv("HELLO_FLEET_ID");
+  std::string save_dir = base_path + "/" + fleet_id + "/calibration_hesais";
+  std::filesystem::create_directories(save_dir);
+  std::string file_path = save_dir + "/right_lidar_calibration.dat";
+  std::ofstream fout(file_path, std::ios::out | std::ios::binary);
+  if (!fout) {
+    printf("FAIL: Can't open file for writing lidar calibration out");
+    return -1;
+  }
+  fout.write(reinterpret_cast<const char*>(sData.data()), sData.size());
+  fout.close();
+  printf("Saved calibration to %s (%zu bytes)\n", file_path.c_str(), sData.size());
+
+  //Set return mode to strongest
+  sample.lidar_ptr_->ptc_client_->SetReturnMode(1); // 1 -> "Strongest" only. Should yield around 115200 points per frame.
+  printf("Set return mode to strongest\n");
+
+  printf("Done. Exiting...\n");
+  return 0;
+}

--- a/tool_ptc/CMakeLists.txt
+++ b/tool_ptc/CMakeLists.txt
@@ -69,6 +69,25 @@ target_link_libraries(ptc_tool PRIVATE
     ptcClient_lib
 )
 
+# ptc_cli interactive PTC test menu
+add_executable(ptc_cli
+    ptc_cli.cc
+    ptc_menu.cc
+    ptc_test_session.cc
+)
+target_include_directories(ptc_cli PRIVATE ${CMAKE_CURRENT_SOURCE_DIR})
+target_link_libraries(ptc_cli PRIVATE
+    ptcClient_lib
+)
+
+# One-lidar network SET smoke test (SetDesIpandPort + SetNet + power-cycle verify)
+add_executable(ptc_network_test
+    ptc_network_test.cc
+)
+target_link_libraries(ptc_network_test PRIVATE
+    ptcClient_lib
+)
+
 # ============================================
 # 构建信息
 # ============================================

--- a/tool_ptc/ptc_cli.cc
+++ b/tool_ptc/ptc_cli.cc
@@ -1,0 +1,86 @@
+#include <cstdlib>
+#include <iostream>
+
+#include "logger.h"
+#include "ptc_menu.h"
+#include "ptc_test_session.h"
+
+using namespace hesai::lidar;
+
+int main(int argc, char **argv)
+{
+  if (argc != 3) {
+    std::cerr << "Usage: " << argv[0] << " <ip> <port>\n";
+    return 1;
+  }
+
+  Logger::GetInstance().setLogTargetRule(LOGTARGET::HESAI_LOG_TARGET_CONSOLE);
+  Logger::GetInstance().setLogLevelRule(
+      LOGLEVEL::HESAI_LOG_WARNING | LOGLEVEL::HESAI_LOG_ERROR |
+      LOGLEVEL::HESAI_LOG_FATAL);
+
+  const std::string ip = argv[1];
+  const uint16_t port = static_cast<uint16_t>(std::atoi(argv[2]));
+  PtcTestSession session(ip, port);
+  if (!session.Connect()) {
+    return 1;
+  }
+
+  while (true) {
+    PtcMenu::PrintMainMenu(ip, port);
+    const int choice = PtcMenu::ReadChoice();
+    switch (choice) {
+      case 0:
+        std::cout << "Bye.\n";
+        return 0;
+      case 1:
+        session.DoReadAll();
+        break;
+      case 2:
+        session.DoGetReturnMode();
+        break;
+      case 3:
+        session.DoGetSpinRate();
+        break;
+      case 4:
+        session.DoGetPtpLockOffset();
+        break;
+      case 5:
+        session.DoGetPointCloudConfig();
+        break;
+      case 6:
+        session.DoGetConfigInfoRaw();
+        break;
+      case 7:
+        session.DoGetPtpDiagnostics();
+        break;
+      case 8:
+        session.DoGetLidarStatus();
+        break;
+      case 9:
+        session.DoGetCalibration();
+        break;
+      case 10:
+        session.DoSetReturnMode();
+        break;
+      case 11:
+        session.DoSetSpinSpeed();
+        break;
+      case 12:
+        session.DoSetPtpLockOffset();
+        break;
+      case 13:
+        session.DoSetPointCloud(false, false);
+        break;
+      case 14:
+        session.DoSetPointCloud(true, false);
+        break;
+      case 15:
+        session.DoSetPointCloud(false, true);
+        break;
+      default:
+        std::cout << "Unknown choice.\n";
+        break;
+    }
+  }
+}

--- a/tool_ptc/ptc_jt128_labels.h
+++ b/tool_ptc/ptc_jt128_labels.h
@@ -1,0 +1,72 @@
+#ifndef PTC_JT128_LABELS_H
+#define PTC_JT128_LABELS_H
+
+#include <cstdint>
+#include <string>
+
+namespace hesai {
+namespace lidar {
+namespace ptc_labels {
+
+inline const char *UltraPreciseLabel(uint8_t value)
+{
+  switch (value) {
+    case 0: return "Low";
+    case 1: return "Medium";
+    case 2: return "Strong";
+    case 3: return "OFF";
+    default: return "unknown";
+  }
+}
+
+inline const char *FilterLabel(uint8_t value)
+{
+  switch (value) {
+    case 0: return "Disabled";
+    case 1: return "Medium";
+    case 2: return "Strong";
+    default: return "unknown";
+  }
+}
+
+inline const char *ReturnModeLabel(uint8_t value)
+{
+  switch (value) {
+    case 0: return "last";
+    case 1: return "strongest";
+    case 2: return "last_and_strongest";
+    case 3: return "first";
+    case 4: return "last_and_first";
+    case 5: return "first_and_strongest";
+    default: return "unknown";
+  }
+}
+
+inline const char *PtpStatusLabel(uint8_t value)
+{
+  switch (value) {
+    case 0: return "Free run";
+    case 1: return "Tracking";
+    case 2: return "Locked";
+    case 3: return "Frozen";
+    default: return "unknown";
+  }
+}
+
+inline std::string FormatPtpStatus(uint8_t value)
+{
+  return std::to_string(value) + " (" + PtpStatusLabel(value) + ")";
+}
+
+inline std::string FormatPointCloudPair(uint8_t ultra, uint8_t filter)
+{
+  return std::string("ultra=") + std::to_string(ultra) + " (" +
+         UltraPreciseLabel(ultra) + ") filter=" + std::to_string(filter) +
+         " (" + FilterLabel(filter) + ")";
+}
+
+}  // namespace ptc_labels
+}  // namespace lidar
+}  // namespace hesai
+
+#endif  // PTC_JT128_LABELS_H

--- a/tool_ptc/ptc_menu.cc
+++ b/tool_ptc/ptc_menu.cc
@@ -1,0 +1,157 @@
+#include "ptc_menu.h"
+
+#include "ptc_client.h"
+#include <cctype>
+#include <iostream>
+#include <limits>
+#include <string>
+
+namespace hesai {
+namespace lidar {
+
+void PtcMenu::PrintMainMenu(const std::string &ip, uint16_t port)
+{
+  std::cout << "\n--- PTC menu (" << ip << ":" << port << ") ---\n"
+            << "  GET\n"
+            << "    1  read_all\n"
+            << "    2  get_return_mode\n"
+            << "    3  get_spin_rate\n"
+            << "    4  get_ptp_lock_offset\n"
+            << "    5  get_point_cloud_config (GET 0x122 live ultra + filter)\n"
+            << "    6  get_config_info_raw (len + head hex)\n"
+            << "    7  get_ptp_diagnostics\n"
+            << "    8  get_lidar_status\n"
+            << "    9  get_calibration (size only)\n"
+            << "  SET\n"
+            << "   10  set_return_mode        -> prompt mode (required)\n"
+            << "   11  set_spin_speed         -> prompt 600 or 1200 RPM (default 600)\n"
+            << "   12  set_ptp_lock_offset    -> prompt 1-1000 us (e.g. 350 for Stretch FAB)\n"
+            << "   13  set_point_cloud        -> prompt ultra + filter (each: value or 'none')\n"
+            << "   14  set_filter_only        -> prompt filter (ultra = keep)\n"
+            << "   15  set_ultra_precise_only -> prompt ultra (filter = keep)\n"
+            << "    0  quit\n"
+            << "Choice: ";
+}
+
+int PtcMenu::ReadChoice()
+{
+  int choice = -1;
+  if (!(std::cin >> choice)) {
+    std::cin.clear();
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    return -1;
+  }
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  return choice;
+}
+
+bool PtcMenu::ReadPointCloudField(const char *field_name, uint8_t &value,
+                                  bool &is_none)
+{
+  std::cout << field_name << " [0-3 ultra / 0-2 filter, or none]: ";
+  std::string line;
+  if (!std::getline(std::cin, line)) {
+    return false;
+  }
+  std::string trimmed = line;
+  trimmed.erase(trimmed.begin(),
+                std::find_if(trimmed.begin(), trimmed.end(),
+                             [](unsigned char ch) { return !std::isspace(ch); }));
+  trimmed.erase(
+      std::find_if(trimmed.rbegin(), trimmed.rend(),
+                   [](unsigned char ch) { return !std::isspace(ch); })
+          .base(),
+      trimmed.end());
+  if (trimmed.empty()) {
+    std::cout << "No input.\n";
+    return false;
+  }
+  for (auto &ch : trimmed) {
+    ch = static_cast<char>(std::tolower(static_cast<unsigned char>(ch)));
+  }
+  if (trimmed == "none") {
+    is_none = true;
+    value = kPointCloudKeepCurrent;
+    return true;
+  }
+  try {
+    int parsed = std::stoi(trimmed);
+    if (parsed < 0 || parsed > 255) {
+      std::cout << "Value out of range.\n";
+      return false;
+    }
+    is_none = false;
+    value = static_cast<uint8_t>(parsed);
+    return true;
+  } catch (...) {
+    std::cout << "Invalid input.\n";
+    return false;
+  }
+}
+
+int PtcMenu::ReadInt(const char *prompt)
+{
+  std::cout << prompt;
+  int value = -1;
+  if (!(std::cin >> value)) {
+    std::cin.clear();
+    std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+    return -1;
+  }
+  std::cin.ignore(std::numeric_limits<std::streamsize>::max(), '\n');
+  return value;
+}
+
+uint16_t PtcMenu::ReadPtpLockOffsetUs()
+{
+  std::cout << "PTP lock offset us [" << kPtpLockOffsetMinUs << "-"
+            << kPtpLockOffsetMaxUs << ", default 350]: ";
+  std::string line;
+  if (!std::getline(std::cin, line)) {
+    return 0;
+  }
+  if (line.empty()) {
+    return 350;
+  }
+  try {
+    int parsed = std::stoi(line);
+    if (parsed < kPtpLockOffsetMinUs || parsed > kPtpLockOffsetMaxUs) {
+      std::cout << "Value must be in [" << kPtpLockOffsetMinUs << ", "
+                << kPtpLockOffsetMaxUs << "].\n";
+      return 0;
+    }
+    return static_cast<uint16_t>(parsed);
+  } catch (...) {
+    std::cout << "Invalid input.\n";
+    return 0;
+  }
+}
+
+uint16_t PtcMenu::ReadSpinRateRpm()
+{
+  std::cout << "spin speed RPM [" << kSpinRateRpm600 << " or "
+            << kSpinRateRpm1200 << ", default " << kSpinRateRpmDefault
+            << "]: ";
+  std::string line;
+  if (!std::getline(std::cin, line)) {
+    return 0;
+  }
+  if (line.empty()) {
+    return kSpinRateRpmDefault;
+  }
+  try {
+    const int parsed = std::stoi(line);
+    if (!IsValidSpinRateRpm(static_cast<uint32_t>(parsed))) {
+      std::cout << "Spin rate must be " << kSpinRateRpm600 << " or "
+                << kSpinRateRpm1200 << " RPM.\n";
+      return 0;
+    }
+    return static_cast<uint16_t>(parsed);
+  } catch (...) {
+    std::cout << "Invalid input.\n";
+    return 0;
+  }
+}
+
+}  // namespace lidar
+}  // namespace hesai

--- a/tool_ptc/ptc_menu.h
+++ b/tool_ptc/ptc_menu.h
@@ -1,0 +1,24 @@
+#ifndef PTC_MENU_H
+#define PTC_MENU_H
+
+#include <cstdint>
+#include <string>
+
+namespace hesai {
+namespace lidar {
+
+class PtcMenu {
+ public:
+  static void PrintMainMenu(const std::string &ip, uint16_t port);
+  static int ReadChoice();
+  static bool ReadPointCloudField(const char *field_name, uint8_t &value,
+                                  bool &is_none);
+  static int ReadInt(const char *prompt);
+  static uint16_t ReadPtpLockOffsetUs();
+  static uint16_t ReadSpinRateRpm();
+};
+
+}  // namespace lidar
+}  // namespace hesai
+
+#endif  // PTC_MENU_H

--- a/tool_ptc/ptc_network_test.cc
+++ b/tool_ptc/ptc_network_test.cc
@@ -1,0 +1,185 @@
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+#include <thread>
+
+#include "logger.h"
+#include "ptc_client.h"
+
+using namespace hesai::lidar;
+
+namespace {
+
+constexpr size_t kConfigDestIpOffset = 12;
+constexpr size_t kConfigDestUdpPortOffset = 16;
+constexpr size_t kConfigMinLen = 18;
+
+const char *kRdkDestIp = "255.255.255.255";
+const char *kRdkNetMask = "255.255.255.0";
+const char *kRdkGateway = "192.168.1.1";
+constexpr uint16_t kDefaultPtcPort = 9347;
+constexpr uint16_t kVlanIdInvalid = 4095;
+
+std::string FormatIpv4FromConfigBytes(const u8Array_t &config, size_t offset)
+{
+  if (config.size() < offset + 4) {
+    return "unknown";
+  }
+  return std::to_string(static_cast<unsigned>(config[offset + 3])) + "." +
+         std::to_string(static_cast<unsigned>(config[offset + 2])) + "." +
+         std::to_string(static_cast<unsigned>(config[offset + 1])) + "." +
+         std::to_string(static_cast<unsigned>(config[offset + 0]));
+}
+
+bool ParseDestUdpPort(const u8Array_t &config, uint16_t &port)
+{
+  if (config.size() < kConfigDestUdpPortOffset + 2) {
+    return false;
+  }
+  port = static_cast<uint16_t>(
+      (static_cast<uint16_t>(config[kConfigDestUdpPortOffset]) << 8) |
+      config[kConfigDestUdpPortOffset + 1]);
+  return true;
+}
+
+bool ReadConfigSummary(PtcClient &client, std::string &device_ip,
+                       std::string &dest_ip, uint16_t &dest_udp_port)
+{
+  u8Array_t config;
+  if (client.GetConfigInfoRaw(config) != 0 || config.size() < kConfigMinLen) {
+    return false;
+  }
+  device_ip = FormatIpv4FromConfigBytes(config, 0);
+  dest_ip = FormatIpv4FromConfigBytes(config, kConfigDestIpOffset);
+  return ParseDestUdpPort(config, dest_udp_port);
+}
+
+bool WaitForOpen(PtcClient &client, const std::string &ip, uint16_t port)
+{
+  std::cout << "Connecting PTC to " << ip << ":" << port << "...\n";
+  while (!client.IsOpen()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  std::cout << "Connected.\n";
+  return true;
+}
+
+void PrintUsage(const char *prog)
+{
+  std::cerr
+      << "Usage: " << prog
+      << " <current_ip> <new_device_ip> <dest_udp_port> [ptc_tcp_port]\n"
+      << "  Example (RDK left): " << prog << " 192.168.1.201 192.168.1.202 2378\n"
+      << "  Default ptc_tcp_port: " << kDefaultPtcPort << "\n";
+}
+
+}  // namespace
+
+int main(int argc, char **argv)
+{
+  if (argc < 4 || argc > 5) {
+    PrintUsage(argv[0]);
+    return 1;
+  }
+
+  Logger::GetInstance().setLogTargetRule(LOGTARGET::HESAI_LOG_TARGET_CONSOLE);
+  Logger::GetInstance().setLogLevelRule(
+      LOGLEVEL::HESAI_LOG_WARNING | LOGLEVEL::HESAI_LOG_ERROR |
+      LOGLEVEL::HESAI_LOG_FATAL);
+
+  const std::string current_ip = argv[1];
+  const std::string new_device_ip = argv[2];
+  const uint16_t dest_udp_port = static_cast<uint16_t>(std::atoi(argv[3]));
+  const uint16_t ptc_port = (argc == 5)
+                                ? static_cast<uint16_t>(std::atoi(argv[4]))
+                                : kDefaultPtcPort;
+
+  std::cout << "============================================================\n"
+            << "WARNING: ONE LIDAR ONLY — network config test tool\n"
+            << "This writes destination UDP + device IP to the connected lidar.\n"
+            << "Network changes take effect after a power cycle.\n"
+            << "============================================================\n\n";
+
+  std::cout << "Plan:\n"
+            << "  connect at:     " << current_ip << ":" << ptc_port << "\n"
+            << "  new device IP:  " << new_device_ip << "\n"
+            << "  dest IP:        " << kRdkDestIp << "\n"
+            << "  dest UDP port:  " << dest_udp_port << "\n\n";
+
+  PtcClient client(current_ip, ptc_port);
+  if (!WaitForOpen(client, current_ip, ptc_port)) {
+    return 1;
+  }
+
+  std::string device_ip;
+  std::string dest_ip;
+  uint16_t read_udp_port = 0;
+  if (ReadConfigSummary(client, device_ip, dest_ip, read_udp_port)) {
+    std::cout << "Before SET:\n"
+              << "  device IP:      " << device_ip << "\n"
+              << "  dest IP:        " << dest_ip << "\n"
+              << "  dest UDP port:  " << read_udp_port << "\n\n";
+  } else {
+    std::cout << "Before SET: GET config info failed\n\n";
+  }
+
+  std::cout << "SET destination IP/port (PTC 0x20)...\n";
+  if (!client.SetDesIpandPort(kRdkDestIp, dest_udp_port, 0)) {
+    std::cerr << "SetDesIpandPort FAILED (ret_code=" << client.ret_code_ << ")\n";
+    return 1;
+  }
+  std::cout << "SetDesIpandPort OK\n";
+
+  std::cout << "SET device network (PTC 0x21)...\n";
+  if (!client.SetNet(new_device_ip, kRdkNetMask, kRdkGateway, 0,
+                     kVlanIdInvalid)) {
+    std::cerr << "SetNet FAILED (ret_code=" << client.ret_code_ << ")\n";
+    return 1;
+  }
+  std::cout << "SetNet OK\n\n";
+
+  std::cout << "Power-cycle the lidar now (disconnect power, reconnect).\n"
+            << "Press Enter when done...";
+  std::cout.flush();
+  std::string line;
+  std::getline(std::cin, line);
+
+  PtcClient verify_client(new_device_ip, ptc_port);
+  if (!WaitForOpen(verify_client, new_device_ip, ptc_port)) {
+    std::cerr << "Could not connect at " << new_device_ip << ":" << ptc_port
+              << " after power cycle.\n";
+    return 1;
+  }
+
+  if (!ReadConfigSummary(verify_client, device_ip, dest_ip, read_udp_port)) {
+    std::cerr << "After power cycle: GET config info failed\n";
+    return 1;
+  }
+
+  std::cout << "\nAfter power cycle:\n"
+            << "  device IP:      " << device_ip << "\n"
+            << "  dest IP:        " << dest_ip << "\n"
+            << "  dest UDP port:  " << read_udp_port << "\n\n";
+
+  const bool ip_ok = (device_ip == new_device_ip);
+  const bool udp_ok = (read_udp_port == dest_udp_port);
+  const bool dest_ip_ok = (dest_ip == kRdkDestIp);
+
+  std::cout << "Verify device IP:      "
+            << (ip_ok ? "PASS" : "FAIL") << " (expected " << new_device_ip
+            << ")\n";
+  std::cout << "Verify dest IP:          "
+            << (dest_ip_ok ? "PASS" : "FAIL") << " (expected " << kRdkDestIp
+            << ")\n";
+  std::cout << "Verify dest UDP port:    "
+            << (udp_ok ? "PASS" : "FAIL") << " (expected " << dest_udp_port
+            << ")\n";
+
+  if (ip_ok && udp_ok && dest_ip_ok) {
+    std::cout << "\nOverall: PASS\n";
+    return 0;
+  }
+  std::cout << "\nOverall: FAIL\n";
+  return 1;
+}

--- a/tool_ptc/ptc_test_session.cc
+++ b/tool_ptc/ptc_test_session.cc
@@ -1,0 +1,472 @@
+#include "ptc_test_session.h"
+
+#include <chrono>
+#include <cmath>
+#include <cstdint>
+#include <cstdio>
+#include <iomanip>
+#include <iostream>
+#include <sstream>
+#include <thread>
+
+#include "ptc_jt128_labels.h"
+#include "ptc_menu.h"
+
+namespace hesai {
+namespace lidar {
+namespace {
+
+constexpr size_t kConfigReturnModeOffset = 32;
+constexpr size_t kConfigDestUdpPortOffset = 16;
+constexpr size_t kConfigMinLen = 33;
+
+}  // namespace
+
+PtcTestSession::PtcTestSession(const std::string &ip, uint16_t port)
+    : ip_(ip),
+      port_(port),
+      client_(nullptr),
+      have_point_cloud_cache_(false),
+      cached_ultra_(0),
+      cached_filter_(0) {}
+
+PtcTestSession::~PtcTestSession() = default;
+
+bool PtcTestSession::Connect()
+{
+  client_ = std::make_unique<PtcClient>(ip_, port_);
+  std::cout << "Waiting for PTC connection to " << ip_ << ":" << port_
+            << "...\n";
+  while (!client_->IsOpen()) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  std::cout << "Connected.\n";
+  return true;
+}
+
+std::string PtcTestSession::HexPreview(const u8Array_t &data,
+                                       size_t max_bytes) const
+{
+  std::ostringstream oss;
+  const size_t n = std::min(data.size(), max_bytes);
+  oss << std::hex << std::setfill('0');
+  for (size_t i = 0; i < n; ++i) {
+    oss << std::setw(2) << static_cast<unsigned>(data[i]);
+  }
+  if (data.size() > max_bytes) {
+    oss << "...";
+  }
+  return oss.str();
+}
+
+bool PtcTestSession::ReadPointCloudConfig(uint8_t &ultra, uint8_t &filter) const
+{
+  return client_->GetPointCloudConfig(ultra, filter);
+}
+
+void PtcTestSession::PrintPointCloudConfigLine(uint8_t ultra,
+                                             uint8_t filter) const
+{
+  std::cout << "point cloud:    "
+            << ptc_labels::FormatPointCloudPair(ultra, filter) << "\n";
+}
+
+void PtcTestSession::PrintPtpStatusLine(uint8_t ptp_status) const
+{
+  std::cout << "ptp_status:     "
+            << ptc_labels::FormatPtpStatus(ptp_status) << "\n";
+}
+
+void PtcTestSession::PrintPtpDiagnosticsFailure(int ret_code,
+                                              uint8_t ptp_status,
+                                              bool have_ptp_status) const
+{
+  std::cout << "get_ptp_diagnostics: cmd 0x06 FAILED (ret_code=" << ret_code
+            << ")\n";
+  if (have_ptp_status) {
+    PrintPtpStatusLine(ptp_status);
+  }
+  if (ret_code == 5 && have_ptp_status && ptp_status == 0) {
+    std::cout << "note: PTP is Free run — master offset diagnostics require "
+                 "Tracking or Locked PTP\n";
+  } else if (have_ptp_status && ptp_status != 2) {
+    std::cout << "note: offset diagnostics usually need PTP Locked; use menu 8 "
+                 "for status\n";
+  }
+}
+
+bool PtcTestSession::SetPointCloudSelective(uint8_t ultra, uint8_t filter)
+{
+  uint8_t current_ultra = 0;
+  uint8_t current_filter = 0;
+  if (!ReadPointCloudConfig(current_ultra, current_filter)) {
+    std::cout << "current config: FAILED to read (GET 0x122)\n";
+    return false;
+  }
+  std::cout << "current config: "
+            << ptc_labels::FormatPointCloudPair(current_ultra, current_filter)
+            << "\n";
+
+  const uint8_t sent_ultra =
+      (ultra == kPointCloudKeepCurrent) ? current_ultra : ultra;
+  const uint8_t sent_filter =
+      (filter == kPointCloudKeepCurrent) ? current_filter : filter;
+
+  const bool ok = client_->SetPointCloudConfigSelective(
+      ultra, filter, have_point_cloud_cache_, cached_ultra_, cached_filter_);
+  std::cout << "sent (0x121):   "
+            << ptc_labels::FormatPointCloudPair(sent_ultra, sent_filter)
+            << "\n";
+  if (!ok) {
+    std::cout << "result:         SET FAILED (ret_code=" << client_->ret_code_
+              << ")\n";
+    return false;
+  }
+
+  std::cout << "result:         SET OK (ret_code=" << client_->ret_code_ << ")\n";
+
+  uint8_t read_ultra = 0;
+  uint8_t read_filter = 0;
+  if (ReadPointCloudConfig(read_ultra, read_filter)) {
+    std::cout << "readback (0x122): "
+              << ptc_labels::FormatPointCloudPair(read_ultra, read_filter)
+              << " "
+              << (read_ultra == sent_ultra && read_filter == sent_filter
+                      ? "MATCH"
+                      : "MISMATCH")
+              << "\n";
+    cached_ultra_ = read_ultra;
+    cached_filter_ = read_filter;
+    have_point_cloud_cache_ = true;
+  } else {
+    std::cout << "readback (0x122): FAILED\n";
+    cached_ultra_ = sent_ultra;
+    cached_filter_ = sent_filter;
+    have_point_cloud_cache_ = true;
+  }
+
+  u8Array_t raw;
+  if (client_->GetPointCloudConfigRaw(raw) == 0) {
+    std::cout << "GET 0x122 raw:  " << HexPreview(raw, raw.size()) << "\n";
+  }
+  return true;
+}
+
+void PtcTestSession::DoReadAll()
+{
+  std::cout << "\n=== read_all ===\n";
+  u8Array_t config;
+  if (client_->GetConfigInfoRaw(config) == 0 && config.size() >= kConfigMinLen) {
+    std::cout << "device IP:      " << static_cast<unsigned>(config[3]) << "."
+              << static_cast<unsigned>(config[2]) << "."
+              << static_cast<unsigned>(config[1]) << "."
+              << static_cast<unsigned>(config[0]) << "\n";
+    if (config.size() >= kConfigDestUdpPortOffset + 2) {
+      const uint16_t dest_port = static_cast<uint16_t>(
+          (static_cast<uint16_t>(config[kConfigDestUdpPortOffset]) << 8) |
+          config[kConfigDestUdpPortOffset + 1]);
+      std::cout << "dest UDP port:  " << dest_port << "\n";
+    }
+    std::cout << "config raw len: " << config.size() << "\n";
+  } else {
+    std::cout << "config info:    FAILED\n";
+  }
+
+  uint8_t return_mode = 0;
+  if (client_->GetReturnMode(return_mode)) {
+    std::cout << "return mode:    " << static_cast<unsigned>(return_mode)
+              << " (" << ptc_labels::ReturnModeLabel(return_mode) << ")\n";
+  } else {
+    std::cout << "return mode:    FAILED\n";
+  }
+
+  uint16_t spin_rate = 0;
+  if (client_->GetSpinRate(spin_rate)) {
+    std::cout << "spin rate:      " << spin_rate << " RPM\n";
+  } else {
+    std::cout << "spin rate:      FAILED\n";
+  }
+
+  uint16_t ptp_offset = 0;
+  if (client_->GetPTPLockOffset(ptp_offset) == 0) {
+    std::cout << "ptp lock offset:" << ptp_offset << " us\n";
+  } else {
+    std::cout << "ptp lock offset:FAILED\n";
+  }
+
+  uint8_t ultra = 0;
+  uint8_t filt = 0;
+  if (ReadPointCloudConfig(ultra, filt)) {
+    PrintPointCloudConfigLine(ultra, filt);
+  } else {
+    std::cout << "point cloud:    FAILED (GET 0x122)\n";
+  }
+
+  uint8_t ptp_status = 0;
+  if (client_->GetLidarPtpStatus(ptp_status)) {
+    PrintPtpStatusLine(ptp_status);
+  } else {
+    std::cout << "ptp_status:     FAILED\n";
+  }
+
+  if (ptp_status == 0) {
+    std::cout << "ptp diagnostics: skipped (PTP Free run)\n";
+  } else {
+    u8Array_t ptp_diag;
+    if (client_->GetPTPDiagnostics(ptp_diag, 1) == 0 && !ptp_diag.empty()) {
+      std::cout << "ptp diagnostics len: " << ptp_diag.size() << "\n";
+      if (ptp_diag.size() >= 8) {
+        const int64_t offset_ns =
+            (static_cast<int64_t>(ptp_diag[0]) << 56) |
+            (static_cast<int64_t>(ptp_diag[1]) << 48) |
+            (static_cast<int64_t>(ptp_diag[2]) << 40) |
+            (static_cast<int64_t>(ptp_diag[3]) << 32) |
+            (static_cast<int64_t>(ptp_diag[4]) << 24) |
+            (static_cast<int64_t>(ptp_diag[5]) << 16) |
+            (static_cast<int64_t>(ptp_diag[6]) << 8) |
+            static_cast<int64_t>(ptp_diag[7]);
+        std::cout << "ptp offset:     " << std::abs(offset_ns / 1000.0)
+                  << " us (" << offset_ns << " ns)\n";
+      }
+    } else {
+      std::cout << "ptp diagnostics: unavailable (ret_code="
+                << client_->ret_code_ << ")\n";
+    }
+  }
+}
+
+void PtcTestSession::DoGetReturnMode()
+{
+  uint8_t return_mode = 0;
+  if (!client_->GetReturnMode(return_mode)) {
+    std::cout << "get_return_mode: FAILED\n";
+    return;
+  }
+  std::cout << "return_mode: " << static_cast<unsigned>(return_mode) << " ("
+            << ptc_labels::ReturnModeLabel(return_mode) << ")\n";
+}
+
+void PtcTestSession::DoGetSpinRate()
+{
+  uint16_t spin_rate = 0;
+  if (!client_->GetSpinRate(spin_rate)) {
+    std::cout << "get_spin_rate: FAILED\n";
+    return;
+  }
+  std::cout << "spin_rate: " << spin_rate << " RPM\n";
+}
+
+void PtcTestSession::DoGetPtpLockOffset()
+{
+  uint16_t offset_us = 0;
+  if (client_->GetPTPLockOffset(offset_us) != 0) {
+    std::cout << "get_ptp_lock_offset: FAILED\n";
+    return;
+  }
+  std::cout << "ptp_lock_offset: " << offset_us << " us\n";
+}
+
+void PtcTestSession::DoGetPointCloudConfig()
+{
+  u8Array_t raw;
+  if (client_->GetPointCloudConfigRaw(raw) != 0) {
+    std::cout << "get_point_cloud_config: GET 0x122 FAILED\n";
+    return;
+  }
+  std::cout << "GET 0x122 raw: " << HexPreview(raw, raw.size()) << "\n";
+
+  uint8_t ultra = 0;
+  uint8_t filt = 0;
+  if (ReadPointCloudConfig(ultra, filt)) {
+    PrintPointCloudConfigLine(ultra, filt);
+  } else {
+    std::cout << "parse: FAILED (expected at least "
+              << kPointCloudLiveConfigMinLen << " bytes)\n";
+  }
+}
+
+void PtcTestSession::DoGetConfigInfoRaw()
+{
+  u8Array_t raw;
+  if (client_->GetConfigInfoRaw(raw) != 0) {
+    std::cout << "get_config_info_raw: FAILED\n";
+    return;
+  }
+  std::cout << "config_info len: " << raw.size() << "\n";
+  std::cout << "config_info head: " << HexPreview(raw, 32) << "\n";
+}
+
+void PtcTestSession::DoGetPtpDiagnostics()
+{
+  uint8_t ptp_status = 0;
+  const bool have_ptp_status = client_->GetLidarPtpStatus(ptp_status);
+
+  u8Array_t raw;
+  if (client_->GetPTPDiagnostics(raw, 1) != 0) {
+    PrintPtpDiagnosticsFailure(client_->ret_code_, ptp_status, have_ptp_status);
+    return;
+  }
+
+  std::cout << "ptp_diagnostics len: " << raw.size() << "\n";
+  if (raw.size() != kPtpDiagnosticsPayloadLen) {
+    std::cout << "note: expected " << kPtpDiagnosticsPayloadLen
+              << " bytes, got " << raw.size() << "\n";
+  }
+  if (raw.size() >= 8) {
+    const int64_t offset_ns =
+        (static_cast<int64_t>(raw[0]) << 56) |
+        (static_cast<int64_t>(raw[1]) << 48) |
+        (static_cast<int64_t>(raw[2]) << 40) |
+        (static_cast<int64_t>(raw[3]) << 32) |
+        (static_cast<int64_t>(raw[4]) << 24) |
+        (static_cast<int64_t>(raw[5]) << 16) |
+        (static_cast<int64_t>(raw[6]) << 8) | static_cast<int64_t>(raw[7]);
+    std::cout << "offset_ns:      " << offset_ns << "\n";
+    std::cout << "offset_us:      " << std::abs(offset_ns / 1000.0) << "\n";
+  }
+  if (raw.size() > 8) {
+    std::cout << "payload head:   " << HexPreview(raw, 32) << "\n";
+  }
+  if (have_ptp_status) {
+    PrintPtpStatusLine(ptp_status);
+  }
+}
+
+void PtcTestSession::DoGetLidarStatus()
+{
+  if (client_->GetLidarStatus() != 0) {
+    std::cout << "get_lidar_status: FAILED\n";
+  }
+}
+
+void PtcTestSession::DoGetCalibration()
+{
+  u8Array_t raw;
+  if (client_->GetCorrectionInfo(raw) != 0) {
+    std::cout << "get_calibration: FAILED\n";
+    return;
+  }
+  std::cout << "calibration size: " << raw.size() << " bytes\n";
+}
+
+void PtcTestSession::PrintSpinSpeedSetFailure(uint16_t requested_rpm) const
+{
+  std::cout << "set_spin_speed: FAILED\n";
+  std::cout << "  allowed:        " << kSpinRateRpm600
+            << " RPM (default), " << kSpinRateRpm1200 << " RPM\n";
+  std::cout << "  requested:      " << requested_rpm << " RPM\n";
+  std::cout << "  command:        PTC 0x17 SET_SPIN_SPEED\n";
+  uint16_t current_rpm = 0;
+  if (client_->GetSpinRate(current_rpm)) {
+    std::cout << "  current config: " << current_rpm << " RPM\n";
+  }
+  if (client_->ret_code_ > 0) {
+    std::cout << "  lidar ret_code: " << client_->ret_code_
+              << " (non-zero = rejected by firmware)\n";
+  } else if (!IsValidSpinRateRpm(requested_rpm)) {
+    std::cout << "  reason:         invalid RPM for JT128\n";
+  }
+}
+
+void PtcTestSession::DoSetReturnMode()
+{
+  const int mode = PtcMenu::ReadInt("return mode [0-5]: ");
+  if (mode < 0 || mode > 255) {
+    std::cout << "Invalid return mode.\n";
+    return;
+  }
+  const uint8_t value = static_cast<uint8_t>(mode);
+  if (!client_->SetReturnMode(value)) {
+    std::cout << "set_return_mode: FAILED (ret_code=" << client_->ret_code_
+              << ")\n";
+    return;
+  }
+  std::cout << "set_return_mode: SET OK\n";
+  uint8_t readback = 0;
+  if (client_->GetReturnMode(readback)) {
+    std::cout << "readback: " << static_cast<unsigned>(readback) << " ("
+              << ptc_labels::ReturnModeLabel(readback) << ") "
+              << (readback == value ? "MATCH" : "MISMATCH") << "\n";
+  }
+}
+
+void PtcTestSession::DoSetSpinSpeed()
+{
+  const uint16_t rpm = PtcMenu::ReadSpinRateRpm();
+  if (rpm == 0) {
+    return;
+  }
+  if (!client_->SetSpinSpeed(rpm)) {
+    PrintSpinSpeedSetFailure(rpm);
+    return;
+  }
+  std::cout << "set_spin_speed: SET OK (" << rpm << " RPM)\n";
+  uint16_t readback = 0;
+  if (client_->GetSpinRate(readback)) {
+    std::cout << "readback: " << readback << " RPM "
+              << (readback == rpm ? "MATCH" : "MISMATCH") << "\n";
+  }
+}
+
+void PtcTestSession::DoSetPtpLockOffset()
+{
+  const uint16_t offset_us = PtcMenu::ReadPtpLockOffsetUs();
+  if (offset_us == 0) {
+    return;
+  }
+  if (!client_->SetPTPLockOffset(offset_us)) {
+    std::cout << "set_ptp_lock_offset: FAILED (ret_code=" << client_->ret_code_
+              << ")\n";
+    return;
+  }
+  std::cout << "set_ptp_lock_offset: SET OK\n";
+  uint16_t readback = 0;
+  if (client_->GetPTPLockOffset(readback) == 0) {
+    std::cout << "readback: " << readback << " us "
+              << (readback == offset_us ? "MATCH" : "MISMATCH") << "\n";
+  }
+}
+
+void PtcTestSession::DoSetPointCloud(bool filter_only, bool ultra_only)
+{
+  uint8_t ultra = kPointCloudKeepCurrent;
+  uint8_t filter = kPointCloudKeepCurrent;
+  bool ultra_none = false;
+  bool filter_none = false;
+
+  if (ultra_only) {
+    if (!PtcMenu::ReadPointCloudField("ultra_precise", ultra, ultra_none)) {
+      return;
+    }
+    if (ultra_none) {
+      std::cout << "ultra_precise is required.\n";
+      return;
+    }
+    filter = kPointCloudKeepCurrent;
+  } else if (filter_only) {
+    if (!PtcMenu::ReadPointCloudField("filter", filter, filter_none)) {
+      return;
+    }
+    if (filter_none) {
+      std::cout << "filter is required.\n";
+      return;
+    }
+    ultra = kPointCloudKeepCurrent;
+  } else {
+    if (!PtcMenu::ReadPointCloudField("ultra_precise", ultra, ultra_none)) {
+      return;
+    }
+    if (!PtcMenu::ReadPointCloudField("filter", filter, filter_none)) {
+      return;
+    }
+    if (ultra_none && filter_none) {
+      std::cout << "At least one of ultra_precise or filter must be provided.\n";
+      return;
+    }
+  }
+
+  SetPointCloudSelective(ultra, filter);
+}
+
+}  // namespace lidar
+}  // namespace hesai

--- a/tool_ptc/ptc_test_session.h
+++ b/tool_ptc/ptc_test_session.h
@@ -1,0 +1,59 @@
+#ifndef PTC_TEST_SESSION_H
+#define PTC_TEST_SESSION_H
+
+#include <cstdint>
+#include <memory>
+#include <string>
+
+#include "ptc_client.h"
+
+namespace hesai {
+namespace lidar {
+
+class PtcTestSession {
+ public:
+  PtcTestSession(const std::string &ip, uint16_t port);
+  ~PtcTestSession();
+
+  bool Connect();
+  const std::string &ip() const { return ip_; }
+  uint16_t port() const { return port_; }
+  PtcClient &client() { return *client_; }
+
+  void DoReadAll();
+  void DoGetReturnMode();
+  void DoGetSpinRate();
+  void DoGetPtpLockOffset();
+  void DoGetPointCloudConfig();
+  void DoGetConfigInfoRaw();
+  void DoGetPtpDiagnostics();
+  void DoGetLidarStatus();
+  void DoGetCalibration();
+
+  void DoSetReturnMode();
+  void DoSetSpinSpeed();
+  void DoSetPtpLockOffset();
+  void DoSetPointCloud(bool filter_only, bool ultra_only);
+
+ private:
+  std::string HexPreview(const u8Array_t &data, size_t max_bytes = 32) const;
+  bool ReadPointCloudConfig(uint8_t &ultra, uint8_t &filter) const;
+  void PrintPointCloudConfigLine(uint8_t ultra, uint8_t filter) const;
+  void PrintPtpStatusLine(uint8_t ptp_status) const;
+  void PrintPtpDiagnosticsFailure(int ret_code, uint8_t ptp_status,
+                                  bool have_ptp_status) const;
+  void PrintSpinSpeedSetFailure(uint16_t requested_rpm) const;
+  bool SetPointCloudSelective(uint8_t ultra, uint8_t filter);
+
+  std::string ip_;
+  uint16_t port_;
+  std::unique_ptr<PtcClient> client_;
+  bool have_point_cloud_cache_;
+  uint8_t cached_ultra_;
+  uint8_t cached_filter_;
+};
+
+}  // namespace lidar
+}  // namespace hesai
+
+#endif  // PTC_TEST_SESSION_H

--- a/tool_ptc/test_instructions.md
+++ b/tool_ptc/test_instructions.md
@@ -1,0 +1,79 @@
+# ptc_cli — build and bench test
+
+Interactive PTC test tool for JT128 lidar over TCP port 9347.
+
+## Build
+
+```bash
+cd ~/HesaiLidar_SDK_2.0/tool_ptc
+mkdir -p build && cd build
+cmake .. && cmake --build . -j$(nproc)
+```
+
+## Run
+
+```bash
+./ptc_cli 192.168.1.202 9347   # left lidar (typical post-RDK)
+./ptc_cli 192.168.1.201 9347   # right lidar or factory IP
+```
+
+Usage: `ptc_cli <ip> <port>`
+
+---
+
+## How to test (GET → SET → GET)
+
+For every **writable** setting, use the same pattern:
+
+1. **GET** — read current value (note baseline)
+2. **SET** — write a test value
+3. **GET again** — confirm readback **MATCH** (CLI prints MATCH/MISMATCH where supported)
+or manually run get again.
+
+Use **menu 1 `read_all`** anytime for a quick snapshot (device IP, dest UDP port, return mode, spin rate, PTP offset, point cloud, PTP status).
+
+---
+
+## Menu reference
+
+```
+  GET
+    1  read_all
+    2  get_return_mode
+    3  get_spin_rate
+    4  get_ptp_lock_offset
+    5  get_point_cloud_config (GET 0x122 live ultra + filter)
+    6  get_config_info_raw (len + head hex — debug)
+    7  get_ptp_diagnostics
+    8  get_lidar_status
+    9  get_calibration (size only)
+  SET
+   10  set_return_mode
+   11  set_spin_speed (600 or 1200 RPM only)
+   12  set_ptp_lock_offset (1–1000 us, e.g. 350)
+   13  set_point_cloud (ultra + filter, or 'none' to keep)
+   14  set_filter_only
+   15  set_ultra_precise_only
+    0  quit
+```
+
+---
+
+## Notes
+
+- **PTP diagnostics (7)** may fail with `ret_code=5` while status is **Free run (0)**; that is expected.
+
+---
+
+## Network SET test (`ptc_network_test`)
+
+**WARNING: one lidar only.** Writes destination UDP + device IP (RDK-style). Requires power cycle.
+
+```bash
+./ptc_network_test <current_ip> <new_device_ip> <dest_udp_port> [ptc_tcp_port]
+
+# RDK left example (factory IP → .202, UDP 2378):
+./ptc_network_test 192.168.1.201 192.168.1.202 2378
+```
+
+Flow: GET config at `current_ip` → SET dest (`255.255.255.255`, UDP port) → SET net (new IP, Stretch mask/gateway) → prompt power cycle → reconnect at `new_device_ip:9347` → GET and PASS/FAIL device IP + dest UDP.


### PR DESCRIPTION
## Summary

Adds JT128-focused **PtcClient** APIs and an interactive bench tool **`ptc_cli`** under `tool_ptc/` to exercise PTC getters/setters against a live lidar over TCP.

Fixes several JT128 protocol mismatches discovered on physical hardware (notably point-cloud GET subcommand and spin-rate validation).

## What changed

### SDK — `libhesai/PtcClient/` (+ `driver/hesai_lidar_sdk.hpp`)

**New / fixed PTC APIs**

| Area | Change |
|---|---|
| Point cloud config | Live GET uses subcmd `0x122` (was incorrectly `0x120`, which returns a ~39-byte descriptor table, not live ultra/filter). SET remains `0x121`. Added `GetPointCloudDescriptorRaw()` for optional `0x120` access. |
| Partial SET | `SetPointCloudConfigSelective()`, `GetPointCloudMergeBase()`, `kPointCloudKeepCurrent` — merge-before-SET for changing only ultra or filter. |
| PTP lock offset | `GetPTPLockOffset(uint16_t&)` parses 2-byte BE µs (1–1000; Stretch FAB uses 350). SET unchanged (2-byte BE). |
| PTP status | `GetLidarStatusRaw()`, `GetLidarPtpStatus()`; `GetLidarStatus()` prints labeled status (Free run, Tracking, Locked, Frozen). |
| Spin rate | `SetSpinSpeed()` validates JT128-allowed values only: 600 or 1200 RPM (600 default). |
| Other getters | `GetConfigInfoRaw()`, `GetReturnMode()`, `GetSpinRate()` (from config info offsets). |

**Driver callback**
- `hesai_lidar_sdk.hpp`: PTP callback now passes `uint16_t` lock offset (supports values > 255).

### New tool — `tool_ptc/ptc_cli`

Interactive menu calling patched `PtcClient` directly (no Python wrapper, no auto-restore):
- `ptc_cli.cc` — main loop
- `ptc_test_session.h/.cc` — connect, GET/SET dispatch, readback checks
- `ptc_menu.h/.cc` — prompts (spin 600/1200, PTP offset, point-cloud `none` for partial SET)
- `ptc_jt128_labels.h` — human-readable labels (return mode, ultra/filter, PTP status)

### New tool — `tool_ptc/ptc_network_test`
**What it does**

> ⚠️ **WARNING — one lidar only**

1. Connect at `current_ip:9347`
2. GET device IP, dest IP, dest UDP
3. SET `SetDesIpandPort(255.255.255.255, udp, 0)` then `SetNet(new_ip, mask, gateway)`
4. Prompt to power-cycle
5. Reconnect at `new_device_ip:9347`
6. GET again → PASS/FAIL for device IP, dest IP, dest UDP

### Unchanged in this PR (reviewers can ignore for testing)
---

## How to build (for testing)

**Prerequisites:** `cmake`, `g++` (C++17), `libssl-dev` (OpenSSL, for `WITH_PTCS_USE`)

```bash
cd HesaiLidar_SDK_2.0/tool_ptc
mkdir -p build && cd build
cmake ..
cmake --build . -j$(nproc)
```

**Run for testing getters and setter**:
```bash
./ptc_cli <ip> <port>

```

**Run for testing Ip and udp setting**:
```bash
./ptc_network_test <current_ip> <new_device_ip> <dest_udp_port> [ptc_tcp_port]

```

